### PR TITLE
Xaml calc v1

### DIFF
--- a/CalculatorApp/CalculatorApp/App.cs
+++ b/CalculatorApp/CalculatorApp/App.cs
@@ -11,34 +11,25 @@ namespace CalculatorApp
     {
         public App()
         {
-            // The root page of your application
-            var content = new ContentPage
-            {
-                Title = "CalculatorApp",
-                Content = new StackLayout
-                {
-                    VerticalOptions = LayoutOptions.Center,
-                    Children = {
-                        new Label {
-                            HorizontalTextAlignment = TextAlignment.Center,
-                            Text = "Welcome to Xamarin Forms!"
-                        }
-                    }
-                }
-            };
-
-            //MainPage = new NavigationPage(content);
             MainPage = new xamlCalculator();
         }
 
         protected override void OnStart()
         {
-            // Handle when your app starts
+            Properties["strOperator"] = "=";
+            Properties["strFirstOperand"] = "";
+            Properties["strSecondOperand"] = "";
+            Properties["strNewEntry"] = "True";
+
+            Properties["strStatus1"] = "";
+            Properties["strStatus2"] = "";
+            Properties["strStatus3"] = "";
+            Properties["strStatus4"] = "";
         }
 
         protected override void OnSleep()
         {
-            // Handle when your app sleeps
+            // Handle when my app goes to sleep
         }
 
         protected override void OnResume()

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -17,9 +17,8 @@
 
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="Auto" />
-        <ColumnDefinition Width="Auto" />
-        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
       
@@ -29,6 +28,7 @@
         TextColor="Yellow"
         FontSize="Small"
         HorizontalOptions="Start"
+        Grid.ColumnSpan="3"
         />
 
       <Label
@@ -41,7 +41,7 @@
         XAlign="End"
         Grid.Row="1"
         Grid.Column="0"
-        Grid.ColumnSpan="5"
+        Grid.ColumnSpan="4"
         FontSize="Large"
         FontAttributes="Bold"
         />
@@ -79,6 +79,8 @@
       <Button
         x:Name="fouButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="4"
         Grid.Row="3"
         Grid.Column="0"
@@ -87,6 +89,8 @@
       <Button
         x:Name="fivButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="5"
         Grid.Row="3"
         Grid.Column="1"
@@ -95,6 +99,8 @@
       <Button
         x:Name="sixButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="6"
         Grid.Row="3"
         Grid.Column="2"
@@ -103,6 +109,8 @@
       <Button
         x:Name="sevButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="7"
         Grid.Row="4"
         Grid.Column="0"
@@ -111,6 +119,8 @@
       <Button
         x:Name="eigButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="8"
         Grid.Row="4"
         Grid.Column="1"
@@ -119,6 +129,8 @@
       <Button
         x:Name="ninButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="9"
         Grid.Row="4"
         Grid.Column="2"
@@ -127,6 +139,8 @@
       <Button
         x:Name="zerButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="0"
         Grid.Row="5"
         Grid.Column="0"
@@ -136,21 +150,28 @@
       <Button
         x:Name="equButton"
         Clicked="OnOperatorButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="="
         Grid.Row="6"
         Grid.Column="2"
-        Grid.ColumnSpan="3"
+        Grid.ColumnSpan="2"
         />
 
       <Button
         x:Name="decButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="."
         Grid.Row="5"
         Grid.Column="2"
         />
 
       <Button
+        x:Name="eclButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="CE"
         Grid.Row="6"
         Grid.Column="0"
@@ -158,41 +179,52 @@
         />
 
       <Button
+        x:Name="cclButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="CC"
         Grid.Row="6"
         Grid.Column="1"
-        Clicked="resetTheInterface"
+        Clicked="OnAllClearButtonClick"
         />
 
       <Button
+        x:Name="pluButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="+"
         Grid.Row="2"
         Grid.Column="3"
-        Grid.ColumnSpan="2"
         Clicked="OnOperatorButtonClick"
         />
 
       <Button
+        x:Name="minButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="-"
         Grid.Row="3"
         Grid.Column="3"
-        Grid.ColumnSpan="2"
         Clicked="OnOperatorButtonClick"
         />
 
       <Button
+        x:Name="mulButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="X"
         Grid.Row="4"
         Grid.Column="3"
-        Grid.ColumnSpan="2"
         Clicked="OnOperatorButtonClick"
         />
 
       <Button
+        x:Name="divButton"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="&#x00F7;"
         Grid.Row="5"
         Grid.Column="3"
-        Grid.ColumnSpan="2"
         Clicked="OnOperatorButtonClick"
         />
       

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -34,6 +34,8 @@
         Grid.Row="1"
         Grid.Column="0"
         Grid.ColumnSpan="5"
+        FontSize="Large"
+        FontAttributes="Bold"
         />
 
       <Button
@@ -126,6 +128,7 @@
 
       <Button
         x:Name="decButton"
+        Clicked="OnNumberButtonClick"
         Text="."
         Grid.Row="5"
         Grid.Column="2"
@@ -135,6 +138,7 @@
         Text="CE"
         Grid.Row="6"
         Grid.Column="0"
+        Clicked="OnClearEntryButtonClick"
         />
 
       <Button
@@ -148,6 +152,7 @@
         Grid.Row="2"
         Grid.Column="3"
         Grid.ColumnSpan="2"
+        Clicked="OnOperatorButtonClick"
         />
 
       <Button
@@ -155,6 +160,7 @@
         Grid.Row="3"
         Grid.Column="3"
         Grid.ColumnSpan="2"
+        Clicked="OnOperatorButtonClick"
         />
 
       <Button
@@ -162,6 +168,7 @@
         Grid.Row="4"
         Grid.Column="3"
         Grid.ColumnSpan="2"
+        Clicked="OnOperatorButtonClick"
         />
 
       <Button
@@ -169,6 +176,7 @@
         Grid.Row="5"
         Grid.Column="3"
         Grid.ColumnSpan="2"
+        Clicked="OnOperatorButtonClick"
         />
       
     </Grid>

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -6,6 +6,7 @@
     <Grid BackgroundColor="Navy">
       <Grid.RowDefinitions>
         <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
         <RowDefinition Height="*" />
         <RowDefinition Height="*" />
         <RowDefinition Height="*" />
@@ -22,105 +23,108 @@
       <Label
         BackgroundColor="White"
         TextColor="Black"
-        Text="The number are gonna go here."
-        Grid.Row="0"
+        Text="0"
+        HorizontalOptions="FillAndExpand"
+        VerticalOptions="FillAndExpand"
+        XAlign="End"
+        Grid.Row="1"
         Grid.Column="0"
         Grid.ColumnSpan="4"
         />
 
       <Button
         Text="1"
-        Grid.Row="1"
+        Grid.Row="2"
         Grid.Column="0"
         />
 
       <Button
         Text="2"
-        Grid.Row="1"
+        Grid.Row="2"
         Grid.Column="1"
         />
 
       <Button
         Text="3"
-        Grid.Row="1"
+        Grid.Row="2"
         Grid.Column="2"
         />
 
       <Button
         Text="4"
-        Grid.Row="2"
+        Grid.Row="3"
         Grid.Column="0"
         />
 
       <Button
         Text="5"
-        Grid.Row="2"
+        Grid.Row="3"
         Grid.Column="1"
         />
 
       <Button
         Text="6"
-        Grid.Row="2"
+        Grid.Row="3"
         Grid.Column="2"
         />
 
       <Button
         Text="7"
-        Grid.Row="3"
+        Grid.Row="4"
         Grid.Column="0"
         />
 
       <Button
         Text="8"
-        Grid.Row="3"
+        Grid.Row="4"
         Grid.Column="1"
         />
 
       <Button
         Text="9"
-        Grid.Row="3"
+        Grid.Row="4"
         Grid.Column="2"
         />
 
       <Button
         Text="0"
-        Grid.Row="4"
+        Grid.Row="5"
         Grid.Column="0"
         />
 
       <Button
         Text="CE"
-        Grid.Row="4"
+        Grid.Row="5"
         Grid.Column="1"
         />
 
       <Button
         Text="C"
-        Grid.Row="4"
+        Grid.Row="5"
         Grid.Column="2"
         />
 
       <Button
         Text="+"
-        Grid.Row="1"
-        Grid.Column="3"
-        />
-
-      <Button
-        Text="-"
         Grid.Row="2"
         Grid.Column="3"
         />
 
       <Button
-        Text="X"
+        Text="-"
         Grid.Row="3"
         Grid.Column="3"
         />
 
       <Button
-        Text="&#x00F7;"
+        Text="X"
         Grid.Row="4"
+        Grid.Column="3"
+        />
+
+      <Button
+        Text="&#x00F7;"
+        Grid.Row="5"
         Grid.Column="3"
         />
       

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -17,11 +17,19 @@
 
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
+      
+      <Label
+        x:Name="statusLabel"
+        Text=""
+        TextColor="Yellow"
+        FontSize="Small"
+        HorizontalOptions="Start"
+        />
 
       <Label
         x:Name="displayLabel"
@@ -41,6 +49,8 @@
       <Button
         x:Name="oneButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="1"
         Grid.Row="2"
         Grid.Column="0"
@@ -49,6 +59,8 @@
       <Button
         x:Name="twoButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="2"
         Grid.Row="2"
         Grid.Column="1"
@@ -57,6 +69,8 @@
       <Button
         x:Name="thrButton"
         Clicked="OnNumberButtonClick"
+        BackgroundColor="Black"
+        TextColor="White"
         Text="3"
         Grid.Row="2"
         Grid.Column="2"
@@ -120,6 +134,8 @@
         />
 
       <Button
+        x:Name="equButton"
+        Clicked="OnOperatorButtonClick"
         Text="="
         Grid.Row="6"
         Grid.Column="2"
@@ -142,9 +158,10 @@
         />
 
       <Button
-        Text="C"
+        Text="CC"
         Grid.Row="6"
         Grid.Column="1"
+        Clicked="resetTheInterface"
         />
 
       <Button

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -3,6 +3,128 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CalculatorApp.xamlCalculator">
   <ContentPage.Content>
-    <Label Text="This is my initial xaml code." />
+    <Grid BackgroundColor="Navy">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="*" />
+        <RowDefinition Height="*" />
+        <RowDefinition Height="*" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+
+      <Label
+        BackgroundColor="White"
+        TextColor="Black"
+        Text="The number are gonna go here."
+        Grid.Row="0"
+        Grid.Column="0"
+        Grid.ColumnSpan="4"
+        />
+
+      <Button
+        Text="1"
+        Grid.Row="1"
+        Grid.Column="0"
+        />
+
+      <Button
+        Text="2"
+        Grid.Row="1"
+        Grid.Column="1"
+        />
+
+      <Button
+        Text="3"
+        Grid.Row="1"
+        Grid.Column="2"
+        />
+
+      <Button
+        Text="4"
+        Grid.Row="2"
+        Grid.Column="0"
+        />
+
+      <Button
+        Text="5"
+        Grid.Row="2"
+        Grid.Column="1"
+        />
+
+      <Button
+        Text="6"
+        Grid.Row="2"
+        Grid.Column="2"
+        />
+
+      <Button
+        Text="7"
+        Grid.Row="3"
+        Grid.Column="0"
+        />
+
+      <Button
+        Text="8"
+        Grid.Row="3"
+        Grid.Column="1"
+        />
+
+      <Button
+        Text="9"
+        Grid.Row="3"
+        Grid.Column="2"
+        />
+
+      <Button
+        Text="0"
+        Grid.Row="4"
+        Grid.Column="0"
+        />
+
+      <Button
+        Text="CE"
+        Grid.Row="4"
+        Grid.Column="1"
+        />
+
+      <Button
+        Text="C"
+        Grid.Row="4"
+        Grid.Column="2"
+        />
+
+      <Button
+        Text="+"
+        Grid.Row="1"
+        Grid.Column="3"
+        />
+
+      <Button
+        Text="-"
+        Grid.Row="2"
+        Grid.Column="3"
+        />
+
+      <Button
+        Text="X"
+        Grid.Row="3"
+        Grid.Column="3"
+        />
+
+      <Button
+        Text="&#x00F7;"
+        Grid.Row="4"
+        Grid.Column="3"
+        />
+      
+    </Grid>
+    
   </ContentPage.Content>
 </ContentPage>

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml
@@ -7,9 +7,11 @@
       <Grid.RowDefinitions>
         <RowDefinition Height="*" />
         <RowDefinition Height="Auto" />
-        <RowDefinition Height="*" />
-        <RowDefinition Height="*" />
-        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
 
@@ -18,9 +20,11 @@
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
 
       <Label
+        x:Name="displayLabel"
         BackgroundColor="White"
         TextColor="Black"
         Text="0"
@@ -29,103 +33,142 @@
         XAlign="End"
         Grid.Row="1"
         Grid.Column="0"
-        Grid.ColumnSpan="4"
+        Grid.ColumnSpan="5"
         />
 
       <Button
+        x:Name="oneButton"
+        Clicked="OnNumberButtonClick"
         Text="1"
         Grid.Row="2"
         Grid.Column="0"
         />
 
       <Button
+        x:Name="twoButton"
+        Clicked="OnNumberButtonClick"
         Text="2"
         Grid.Row="2"
         Grid.Column="1"
         />
 
       <Button
+        x:Name="thrButton"
+        Clicked="OnNumberButtonClick"
         Text="3"
         Grid.Row="2"
         Grid.Column="2"
         />
 
       <Button
+        x:Name="fouButton"
+        Clicked="OnNumberButtonClick"
         Text="4"
         Grid.Row="3"
         Grid.Column="0"
         />
 
       <Button
+        x:Name="fivButton"
+        Clicked="OnNumberButtonClick"
         Text="5"
         Grid.Row="3"
         Grid.Column="1"
         />
 
       <Button
+        x:Name="sixButton"
+        Clicked="OnNumberButtonClick"
         Text="6"
         Grid.Row="3"
         Grid.Column="2"
         />
 
       <Button
+        x:Name="sevButton"
+        Clicked="OnNumberButtonClick"
         Text="7"
         Grid.Row="4"
         Grid.Column="0"
         />
 
       <Button
+        x:Name="eigButton"
+        Clicked="OnNumberButtonClick"
         Text="8"
         Grid.Row="4"
         Grid.Column="1"
         />
 
       <Button
+        x:Name="ninButton"
+        Clicked="OnNumberButtonClick"
         Text="9"
         Grid.Row="4"
         Grid.Column="2"
         />
 
       <Button
+        x:Name="zerButton"
+        Clicked="OnNumberButtonClick"
         Text="0"
         Grid.Row="5"
         Grid.Column="0"
+        Grid.ColumnSpan="2"
+        />
+
+      <Button
+        Text="="
+        Grid.Row="6"
+        Grid.Column="2"
+        Grid.ColumnSpan="3"
+        />
+
+      <Button
+        x:Name="decButton"
+        Text="."
+        Grid.Row="5"
+        Grid.Column="2"
         />
 
       <Button
         Text="CE"
-        Grid.Row="5"
-        Grid.Column="1"
+        Grid.Row="6"
+        Grid.Column="0"
         />
 
       <Button
         Text="C"
-        Grid.Row="5"
-        Grid.Column="2"
+        Grid.Row="6"
+        Grid.Column="1"
         />
 
       <Button
         Text="+"
         Grid.Row="2"
         Grid.Column="3"
+        Grid.ColumnSpan="2"
         />
 
       <Button
         Text="-"
         Grid.Row="3"
         Grid.Column="3"
+        Grid.ColumnSpan="2"
         />
 
       <Button
         Text="X"
         Grid.Row="4"
         Grid.Column="3"
+        Grid.ColumnSpan="2"
         />
 
       <Button
         Text="&#x00F7;"
         Grid.Row="5"
         Grid.Column="3"
+        Grid.ColumnSpan="2"
         />
       
     </Grid>

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
@@ -14,5 +14,42 @@ namespace CalculatorApp
         {
             InitializeComponent();
         }
+
+        void OnNumberButtonClick(object sender, EventArgs args)
+        {
+            // Add the digit pushed to the right-most position of the display
+            Button btn = (Button)sender;
+
+            string strNumberName = btn.ToString().Substring(0,3);
+            string strNumberDigit = null;
+
+            if (btn == oneButton) { strNumberDigit = "1"; }
+            if (btn == twoButton) { strNumberDigit = "2"; }
+            if (btn == thrButton) { strNumberDigit = "3"; }
+            if (btn == fouButton) { strNumberDigit = "4"; }
+            if (btn == fivButton) { strNumberDigit = "5"; }
+            if (btn == sixButton) { strNumberDigit = "6"; }
+            if (btn == sevButton) { strNumberDigit = "7"; }
+            if (btn == eigButton) { strNumberDigit = "8"; }
+            if (btn == ninButton) { strNumberDigit = "9"; }
+            if (btn == zerButton) { strNumberDigit = "0"; }
+            if (btn == decButton) { strNumberDigit = "."; }
+
+            string strDisplay = displayLabel.Text.Trim();
+
+            // if the display is already zero, dump it so we don't end up with a leading zero
+            if (strDisplay == "0") { strDisplay = ""; }
+
+            if(strDisplay.Length < 15)
+            {
+                if(strNumberDigit != "." || strDisplay.IndexOf(".") == 0 )
+                {
+                    strDisplay += strNumberDigit.Trim();
+                }
+                
+            }
+
+            displayLabel.Text = strDisplay;
+        }
     }
 }

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
@@ -20,36 +20,33 @@ namespace CalculatorApp
             // Add the digit pushed to the right-most position of the display
             Button btn = (Button)sender;
 
-            string strNumberName = btn.ToString().Substring(0,3);
-            string strNumberDigit = null;
-
-            if (btn == oneButton) { strNumberDigit = "1"; }
-            if (btn == twoButton) { strNumberDigit = "2"; }
-            if (btn == thrButton) { strNumberDigit = "3"; }
-            if (btn == fouButton) { strNumberDigit = "4"; }
-            if (btn == fivButton) { strNumberDigit = "5"; }
-            if (btn == sixButton) { strNumberDigit = "6"; }
-            if (btn == sevButton) { strNumberDigit = "7"; }
-            if (btn == eigButton) { strNumberDigit = "8"; }
-            if (btn == ninButton) { strNumberDigit = "9"; }
-            if (btn == zerButton) { strNumberDigit = "0"; }
-            if (btn == decButton) { strNumberDigit = "."; }
-
+            string strNumberDigit = btn.Text.Trim();
             string strDisplay = displayLabel.Text.Trim();
 
             // if the display is already zero, dump it so we don't end up with a leading zero
-            if (strDisplay == "0") { strDisplay = ""; }
+            // unless we are entering a decimal point, then leave the leading zero
+            if (strDisplay == "0" && strNumberDigit != ".") { strDisplay = ""; }
 
             if(strDisplay.Length < 15)
             {
-                if(strNumberDigit != "." || strDisplay.IndexOf(".") == 0 )
+                if (strNumberDigit != "." || strDisplay.IndexOf(".") == -1)
                 {
                     strDisplay += strNumberDigit.Trim();
                 }
                 
             }
 
-            displayLabel.Text = strDisplay;
+            displayLabel.Text = strDisplay.Trim();
+        }
+
+        void OnClearEntryButtonClick(object sender, EventArgs args)
+        {
+            displayLabel.Text = "0";
+        }
+
+        void OnOperatorButtonClick(object sender, EventArgs args)
+        {
+            displayLabel.Text = "99999.9999";
         }
     }
 }

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
@@ -17,11 +17,15 @@ namespace CalculatorApp
 
         void OnNumberButtonClick(object sender, EventArgs args)
         {
-            // Add the digit pushed to the right-most position of the display
             Button btn = (Button)sender;
 
             string strNumberDigit = btn.Text.Trim();
             string strDisplay = displayLabel.Text.Trim();
+
+            // if this is a new entry (we just displayed a calculation result)
+            //  then set the display value to zero so we start entering a brand new number
+            bool booNewEntry = Convert.ToBoolean(Application.Current.Properties["strNewEntry"].ToString());
+            if (booNewEntry) { strDisplay = "0"; }
 
             // if the display is already zero, dump it so we don't end up with a leading zero
             // unless we are entering a decimal point, then leave the leading zero
@@ -36,6 +40,8 @@ namespace CalculatorApp
                 
             }
 
+            // we have a digit so it's not a new entry anymore
+            Application.Current.Properties["strNewEntry"] = "False";
             displayLabel.Text = strDisplay.Trim();
         }
 
@@ -46,7 +52,111 @@ namespace CalculatorApp
 
         void OnOperatorButtonClick(object sender, EventArgs args)
         {
-            displayLabel.Text = "99999.9999";
+            Button btn = (Button)sender;
+
+            string strNextOperator = btn.Text;
+            string strOperator = Application.Current.Properties["strOperator"].ToString();
+
+            double dblFirstOperand;
+            double dblSecondOperand = Convert.ToDouble(displayLabel.Text);
+
+            double dblResult;
+
+            switch (strOperator)
+            {
+                case "=":
+                    dblFirstOperand = dblSecondOperand;
+                    dblResult = dblSecondOperand;
+                    break;
+
+                case "+":
+                    // if we haven't loaded a first operand yet, as at app start-up, we'll use 0 as our first number to add
+                    if (Application.Current.Properties["strFirstOperand"].ToString()=="")
+                    {
+                        dblFirstOperand = 0;
+                    }
+                    else
+                    {
+                        dblFirstOperand =  Convert.ToDouble(Application.Current.Properties["strFirstOperand"]);
+                    }
+
+                    dblResult = dblFirstOperand + dblSecondOperand;
+                    break;
+
+                case "-":
+                    // if we haven't loaded a first operand yet, as at app start-up, we'll use 0 as our first number to add
+                    if (Application.Current.Properties["strFirstOperand"].ToString() == "")
+                    {
+                        dblFirstOperand = 0;
+                    }
+                    else
+                    {
+                        dblFirstOperand = Convert.ToDouble(Application.Current.Properties["strFirstOperand"]);
+                    }
+
+                    dblResult = dblFirstOperand - dblSecondOperand;
+                    break;
+
+                case "X":
+                    // if we haven't loaded a first operand yet, as at app start-up, we'll just multiply by 1
+                    if (Application.Current.Properties["strFirstOperand"].ToString() == "")
+                    {
+                        dblFirstOperand = 1;
+                    }
+                    else
+                    {
+                        dblFirstOperand = Convert.ToDouble(Application.Current.Properties["strFirstOperand"]);
+                    }
+
+                    dblResult = dblFirstOperand * dblSecondOperand;
+                    break;
+
+                default:
+                    dblFirstOperand = -99999.99999;
+                    dblResult = -99999.99999;
+                    break;
+
+            }
+
+            string strNewStatus = "";
+            if (strOperator != "=")
+            {
+                strNewStatus += dblFirstOperand.ToString()
+                + " " + strOperator + " "
+                + dblSecondOperand.ToString()
+                + " = " + dblResult.ToString();
+
+                scrollUpStatusDisplay(strNewStatus);
+            }
+
+            Application.Current.Properties["strOperator"] = strNextOperator;
+            Application.Current.Properties["strFirstOperand"] = dblResult.ToString();
+            Application.Current.Properties["strNewEntry"] = "True";
+
+            displayLabel.Text = dblResult.ToString();
+        }
+
+        void resetTheInterface(object sender, EventArgs args)
+        {
+            Application.Current.Properties["strOperator"] = "=";
+            Application.Current.Properties["strFirstOperand"] = "";
+            Application.Current.Properties["strSecondOperand"] = "";
+            Application.Current.Properties["strNewEntry"] = "True";
+
+            displayLabel.Text = "0";
+        }
+
+        void scrollUpStatusDisplay(string strNewStatus)
+        {
+            Application.Current.Properties["strStatus1"] = Application.Current.Properties["strStatus2"];
+            Application.Current.Properties["strStatus2"] = Application.Current.Properties["strStatus3"];
+            Application.Current.Properties["strStatus3"] = Application.Current.Properties["strStatus4"];
+            Application.Current.Properties["strStatus4"] = strNewStatus;
+
+            statusLabel.Text = Application.Current.Properties["strStatus1"] + "\n"
+                + Application.Current.Properties["strStatus2"] + "\n"
+                + Application.Current.Properties["strStatus3"] + "\n"
+                + Application.Current.Properties["strStatus4"];
         }
     }
 }

--- a/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
+++ b/CalculatorApp/CalculatorApp/xamlCalculator.xaml.cs
@@ -17,6 +17,11 @@ namespace CalculatorApp
 
         void OnNumberButtonClick(object sender, EventArgs args)
         {
+            if (displayLabel.Text == "OVERFLOW")
+            {
+                displayLabel.Text = "0";
+            }
+
             Button btn = (Button)sender;
 
             string strNumberDigit = btn.Text.Trim();
@@ -52,6 +57,13 @@ namespace CalculatorApp
 
         void OnOperatorButtonClick(object sender, EventArgs args)
         {
+            if(displayLabel.Text == "OVERFLOW")
+            {
+                resetTheInterface();
+            }
+
+            bool booOverflow = false;
+
             Button btn = (Button)sender;
 
             string strNextOperator = btn.Text;
@@ -108,7 +120,53 @@ namespace CalculatorApp
                         dblFirstOperand = Convert.ToDouble(Application.Current.Properties["strFirstOperand"]);
                     }
 
-                    dblResult = dblFirstOperand * dblSecondOperand;
+                    try
+                    {
+                        dblResult = dblFirstOperand * dblSecondOperand;
+                    }
+                    catch
+                    {
+                        booOverflow = true;
+                        dblResult = -99999.99999;
+                    }
+
+                    // who woulda thunk it. No error, it comes back as infinity
+                    if (dblResult.ToString() == "Infinity")
+                    {
+                        booOverflow = true;
+                        dblResult = -99999.99999;
+                    }
+
+                    break;
+
+                case "\u00F7":
+                    // if we haven't loaded a first operand yet, as at app start-up, we'll just multiply by 1
+                    if (Application.Current.Properties["strFirstOperand"].ToString() == "")
+                    {
+                        dblFirstOperand = 1;
+                    }
+                    else
+                    {
+                        dblFirstOperand = Convert.ToDouble(Application.Current.Properties["strFirstOperand"]);
+                    }
+
+                    try
+                    {
+                        dblResult = dblFirstOperand / dblSecondOperand;
+                    }
+                    catch
+                    {
+                        booOverflow = true;
+                        dblResult = -99999.99999;
+                    }
+
+                    // who woulda thunk it. No error, it comes back as infinity
+                    if (dblResult.ToString() == "Infinity")
+                    {
+                        booOverflow = true;
+                        dblResult = -99999.99999;
+                    }
+                    
                     break;
 
                 default:
@@ -119,24 +177,44 @@ namespace CalculatorApp
             }
 
             string strNewStatus = "";
-            if (strOperator != "=")
+
+            if (booOverflow)
             {
-                strNewStatus += dblFirstOperand.ToString()
-                + " " + strOperator + " "
-                + dblSecondOperand.ToString()
-                + " = " + dblResult.ToString();
+                displayLabel.Text = "OVERFLOW";
+                strNewStatus = "Overflow";
 
                 scrollUpStatusDisplay(strNewStatus);
             }
+            else
+            {
+                if (strOperator != "=")
+                {
+                    strNewStatus += dblFirstOperand.ToString()
+                    + " " + strOperator + " "
+                    + dblSecondOperand.ToString()
+                    + " = " + dblResult.ToString();
 
-            Application.Current.Properties["strOperator"] = strNextOperator;
-            Application.Current.Properties["strFirstOperand"] = dblResult.ToString();
-            Application.Current.Properties["strNewEntry"] = "True";
+                    scrollUpStatusDisplay(strNewStatus);
+                }
 
-            displayLabel.Text = dblResult.ToString();
+                Application.Current.Properties["strOperator"] = strNextOperator;
+                Application.Current.Properties["strFirstOperand"] = dblResult.ToString();
+                Application.Current.Properties["strNewEntry"] = "True";
+
+                // Trying to get the Android to keep the display left-justified but it won't
+                displayLabel.HorizontalTextAlignment = TextAlignment.End;
+                displayLabel.HorizontalOptions = LayoutOptions.FillAndExpand;
+
+                displayLabel.Text = dblResult.ToString();
+            }
         }
 
-        void resetTheInterface(object sender, EventArgs args)
+        void OnAllClearButtonClick(object sender, EventArgs args)
+        {
+            resetTheInterface();
+        }
+
+        void resetTheInterface()
         {
             Application.Current.Properties["strOperator"] = "=";
             Application.Current.Properties["strFirstOperand"] = "";


### PR DESCRIPTION
Has two bugs I could not resolve.
1) On Android, the main display aligns right as I intended but whenever an operator button (+, -, =) is hit, the display aligns left. It returns to right-aligned when entering numbers.
2) On WinPhone 8.1 the buttons are trimmed off slightly on the right side of each. I could not get them to be any narrower which looks bad. I think a 3-column arrangement would solve this but would make the app less user-friendly so I kept it as is.